### PR TITLE
set stream level for streamhandler

### DIFF
--- a/dfds_ds_toolbox/logging/logging.py
+++ b/dfds_ds_toolbox/logging/logging.py
@@ -65,6 +65,7 @@ def init_logger(
 
     # Set up logger
     logger = logging.getLogger(name)
+    # Setting logger root level (it could be override by specific handler levels)
     logger.setLevel(logging.DEBUG)
     if rich_handler_enabled and log_format is not None:
         raise ValueError("Rich handler and custom log format cannot be used together")
@@ -91,6 +92,7 @@ def init_logger(
     else:
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter(log_format))
+        handler.setLevel(level=stream_level)
     logger.addHandler(handler)
 
     return logger

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name="dfds_ds_toolbox",
     packages=find_packages(exclude=["*tests*"]),
     keywords=["dfds_ds_toolbox", "data science"],
-    version="0.9.1",
+    version="0.9.2",
     description="A collection of tools for data science used at DFDS.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -35,7 +35,6 @@ def debug_file(tmp_path):
     """Fixture. Generate debug file location for tests."""
     return tmp_path.joinpath("pytest-plugin.log")
 
-
 def test_instance_logger():
     """Test we can create instance of logger."""
     logger = init_logger()
@@ -125,3 +124,14 @@ def test_no_rich_handler():
     assert isinstance(
         no_rich_logger, logging.Logger
     ), "Logger without rich handler could not be initialized"
+
+def test_info_level_no_rich_handler():
+    """Test that the level is right for logger without rich handler"""
+    no_rich_logger_info = init_logger(stream_level="INFO", rich_handler_enabled=False)
+    assert no_rich_logger_info.handlers[0].level == logging.INFO, "Stream level of the handler is not INFO"
+
+
+def test_default_level_no_rich_handler():
+    """Test that the default level is right for logger without rich handler"""
+    no_rich_logger_default = init_logger(rich_handler_enabled=False)
+    assert no_rich_logger_default.handlers[0].level == logging.WARNING, "Stream level of the handler is not WARNING (default logger root level)"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -35,6 +35,7 @@ def debug_file(tmp_path):
     """Fixture. Generate debug file location for tests."""
     return tmp_path.joinpath("pytest-plugin.log")
 
+
 def test_instance_logger():
     """Test we can create instance of logger."""
     logger = init_logger()
@@ -125,13 +126,18 @@ def test_no_rich_handler():
         no_rich_logger, logging.Logger
     ), "Logger without rich handler could not be initialized"
 
+
 def test_info_level_no_rich_handler():
     """Test that the level is right for logger without rich handler"""
     no_rich_logger_info = init_logger(stream_level="INFO", rich_handler_enabled=False)
-    assert no_rich_logger_info.handlers[0].level == logging.INFO, "Stream level of the handler is not INFO"
+    assert (
+        no_rich_logger_info.handlers[0].level == logging.INFO
+    ), "Stream level of the handler is not INFO"
 
 
 def test_default_level_no_rich_handler():
     """Test that the default level is right for logger without rich handler"""
     no_rich_logger_default = init_logger(rich_handler_enabled=False)
-    assert no_rich_logger_default.handlers[0].level == logging.WARNING, "Stream level of the handler is not WARNING (default logger root level)"
+    assert (
+        no_rich_logger_default.handlers[0].level == logging.WARNING
+    ), "Stream level of the handler is not WARNING (default logger root level)"


### PR DESCRIPTION
Oops. 
The logger has a default root level (DEBUG). If the stream level to the handler is not specified, it will log all messages equal or higher than DEBUG.

In this PR we fix the bug by specifying the stream level to the StreamHandler, as we were doing to the RichHandler.

Added a test to avoid the same issue in the future