### PR TITLE
Change documentation to consistently use the right package name

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: pytester-cov
       id: pytester-cov
-      uses: alexanderdamiani/pytester-cov@v1.2.0
+      uses: programmingwithalex/pytester-cov@main
       with:
         pytest-root-dir: '.'
         cov-omit-list: 'tests/*, docs/*, setup.py, examples/*'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       name: isort
 
 -   repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 22.3.0
     hooks:
     -   id: black
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
-.. ds_toolbox documentation master file, created by
+.. dfds_ds_toolbox documentation master file, created by
    sphinx-quickstart on Wed Oct 20 12:26:48 2021.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to ds_toolbox's documentation!
+Welcome to dfds_ds_toolbox's documentation!
 ======================================
 
 .. toctree::

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,7 @@
-ds_toolbox
+dfds_ds_toolbox
 ==========
 
 .. toctree::
    :maxdepth: 4
 
-   ds_toolbox
+   dfds_ds_toolbox

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,7 +8,7 @@ Model selection
 ---------------
 Start by importing the switcher class from `model_selection`.::
 
-    from ds_toolbox.model_selection.model_selection import ClfSwitcher, RegSwitcher
+    from dfds_ds_toolbox.model_selection.model_selection import ClfSwitcher, RegSwitcher
 
 In this module there are two switcher classes; one for classification (:py:class:`ClfSwitcher`)
 and one for regression (:py:class:`RegSwitcher`). The switcher classes each implement a base class that
@@ -118,7 +118,7 @@ An example of implementation can be found in  with the ``@profileit()`` decorato
 
 We can then add the decorator to whatever function we want to profile::
 
-    from ds_toolbox.profiling.profiling import profileit
+    from dfds_ds_toolbox.profiling.profiling import profileit
     from pathlib import Path
 
     @profileit(path=Path("profiles/"), name="main_script_profile")
@@ -140,7 +140,7 @@ The logging module allows you to easily log in console or/and in a debug file wi
 
 Usage::
 
-    >>> from ds_toolbox.logging.logging import init_logger
+    >>> from dfds_ds_toolbox.logging.logging import init_logger
     >>> logger = init_logger()
     >>> logger.info("This message will not be logged.")
     >>> logger.critical("Something BAD happened.")

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,4 +1,4 @@
 Example gallery
 ===============
 
-Below is a gallery of example plots in `ds_toolbox`.
+Below is a gallery of example plots in `dfds_ds_toolbox`.


### PR DESCRIPTION
I have changed the documentation so that it imports the right package, i.e. `dfds_ds_toolbox` instead of `ds_toolbox` 📦 

I found that the CI failed. To fix it I've updated the **github action** that makes the test coverage report and also I've updated the version of `black` used in `pre-commit` because of an issue with the old one   :blush:(https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click) 